### PR TITLE
Fixed case on default mode and disabled mode

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,8 +14,8 @@ export const URI_SUBCAT_ACTION = "action";
 export const URI_SET_INTELLISENSE_ENGINE = "intelliSenseEngine";
 
 export const URI_VAL_TAGPARSER = "Tag Parser";
-export const URI_VAL_DEFAULT = "Default";
-export const URI_VAL_DISABLED = "Disabled";
+export const URI_VAL_DEFAULT = "default";
+export const URI_VAL_DISABLED = "disabled";
 export const URI_VAL_LOCK_TOGGLE = "lockToggle";
 
 export const URI_FUL_RELOAD_WINDOW = "workbench.action.reloadWindow";


### PR DESCRIPTION
VSCode is giving a squiggle yellow line on the `"Default"` value of the `"C_Cpp.intelliSenseEngine": "Default"` key on the *.code-workspace file. Not sure if this is the proper fix or even if this is a mac only thing. The error says:
`Value is not accepted. Valid values: "default", "Tag Parser", "disabled".`